### PR TITLE
test/test Add function stubs for native and applicable (ignored) tests.

### DIFF
--- a/src/frameworks/mod.rs
+++ b/src/frameworks/mod.rs
@@ -1,8 +1,8 @@
 //! Provides the specific Framework implementations for the Library Operations.
 
-//#[cfg(feature = "native")]
-//mod native;
+#[cfg(feature = "native")]
+pub mod native;
 //#[cfg(feature = "opencl")]
-//mod opencl;
+//pub mod opencl;
 #[cfg(feature = "cuda")]
 pub mod cuda;

--- a/src/frameworks/native.rs
+++ b/src/frameworks/native.rs
@@ -1,7 +1,5 @@
-//! Provides BLAS for a Native backend.
+//! Provides NN for a Native backend.
 
-use ::operation::*;
-use ::binary::*;
 use ::plugin::*;
 use co::device::DeviceType;
 use co::backend::Backend;
@@ -9,65 +7,425 @@ use co::memory::MemoryType;
 use co::frameworks::native::{Native, Function, Binary};
 use co::plugin::Error;
 
-macro_rules! impl_binary(($($t: ident), +) => (
-    $(
-        impl INnBinary<$t> for Binary {
-            type Sigmoid = Function;
+struct ConvolutionConfig { dummy: i32 }
 
-            fn sigmoid(&self) -> Self::Sigmoid {
-                self.blas_asum
-            }
-        }
+#[macro_export]
+macro_rules! impl_oconf_for_cc(($($t: ident), +) => (
+    $(
+        impl<'a> NNOperationConfig<$t> for ConvolutionConfig { }
     )+
 ));
 
-macro_rules! impl_sigmoid_for {
+struct NormalizationConfig { dummy: i32 }
+
+#[macro_export]
+macro_rules! impl_oconf_for_clrn(($($t: ident), +) => (
+    $(
+        impl NNOperationConfig<$t> for NormalizationConfig { }
+    )+
+));
+
+struct PoolingConfig { dummy: i32 }
+
+#[macro_export]
+macro_rules! impl_oconf_for_pooling(($($t: ident), +) => (
+    $(
+        impl NNOperationConfig<$t> for PoolingConfig { }
+    )+
+));
+
+
+macro_rules! impl_ops_sigmoid_for {
     ($t:ident, $b:ty) => (
-        impl IOperationSigmoid<$t> for $b {
-            fn compute(&self, x: &MemoryType, result: &mut MemoryType) -> Result<(), Error> {
-                unimplemented!()
-            }
+        fn sigmoid(
+            &self,
+            x: &mut ::co::tensor::SharedTensor<$t>,
+            result: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn sigmoid_plain(
+            &self,
+            x: &::co::tensor::SharedTensor<$t>,
+            result: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn sigmoid_grad(
+            &self,
+            x: &mut ::co::tensor::SharedTensor<$t>,
+            x_diff: &mut ::co::tensor::SharedTensor<$t>,
+            result: &mut ::co::tensor::SharedTensor<$t>,
+            result_diff: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn sigmoid_grad_plain(
+            &self,
+            x: &::co::tensor::SharedTensor<$t>,
+            x_diff: &::co::tensor::SharedTensor<$t>,
+            result: &::co::tensor::SharedTensor<$t>,
+            result_diff: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
         }
     );
 }
 
-macro_rules! impl_plugin_for {
+macro_rules! impl_ops_relu_for {
     ($t:ident, $b:ty) => (
-        impl_sigmoid_for!($t, $b);
+        fn relu(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn relu_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn relu_grad(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            x_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn relu_grad_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            x_diff: &::co::tensor::SharedTensor<$t>, 
+            result: &::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
     );
 }
 
-impl_binary!(f32, f64);
-impl_plugin_for!(f32, Function);
-impl_plugin_for!(f64, Function);
+macro_rules! impl_ops_tanh_for {
+    ($t:ident, $b:ty) => (
+        fn tanh(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn tanh_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn tanh_grad(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            x_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
 
-impl_plugin_for!(f32, Backend<Native>);
-impl_plugin_for!(f64, Backend<Native>);
+        fn tanh_grad_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            x_diff: &::co::tensor::SharedTensor<$t>, 
+            result: &::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+    );
+}
 
-impl INn<f32> for Backend<Native> {
-    type B = Binary;
+macro_rules! impl_ops_convolution_for {
+    ($t:ident, $b:ty) => (
+        fn convolution(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CC
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn convolution_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CC
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn convolution_grad(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            x_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CC
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn convolution_grad_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            x_diff: &::co::tensor::SharedTensor<$t>, 
+            result: &::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CC
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+    );
+}
+
+macro_rules! impl_ops_softmax_for {
+    ($t:ident, $b:ty) => (
+        fn softmax(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn softmax_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn softmax_grad(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            x_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        fn softmax_grad_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            x_diff: &::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+    );
+}
+
+macro_rules! impl_ops_lrn_for {
+    ($t:ident, $b:ty) => (
+        fn new_lrn_config(
+        &self, 
+        n: u32, 
+        alpha: f64, 
+        beta: f64, 
+        k: f64
+        ) -> Result<Self::CLRN, ::co::error::Error> {
+            unimplemented!();
+            Ok(NormalizationConfig{dummy: 7})
+        }
+
+        fn lrn(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CLRN
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn lrn_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CLRN
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn lrn_grad(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            x_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CLRN
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn lrn_grad_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            x_diff: &::co::tensor::SharedTensor<$t>, 
+            result: &::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CLRN
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+    );
+}
+
+macro_rules! impl_ops_pooling_for {
+    ($t:ident, $b:ty) => (
+        fn new_pooling_config(
+            &self, 
+            window: &[i32], 
+            padding: &[i32], 
+            stride: &[i32]
+        ) -> Result<Self::CPOOL, ::co::error::Error> {
+            unimplemented!();
+            Ok(PoolingConfig{dummy: 6})
+        }
+
+        fn pooling_max(
+            &self, 
+            x: &mut ::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CPOOL
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn pooling_max_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            result: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CPOOL
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+        #[allow(unused_variables)]
+        fn pooling_max_grad(
+            &self,
+            x: &mut ::co::tensor::SharedTensor<$t>,
+            x_diff: &mut ::co::tensor::SharedTensor<$t>,
+            result: &mut ::co::tensor::SharedTensor<$t>,
+            result_diff: &mut ::co::tensor::SharedTensor<$t>,
+            config: &Self::CPOOL
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+
+        fn pooling_max_grad_plain(
+            &self, 
+            x: &::co::tensor::SharedTensor<$t>, 
+            x_diff: &::co::tensor::SharedTensor<$t>, 
+            result: &::co::tensor::SharedTensor<$t>, 
+            result_diff: &mut ::co::tensor::SharedTensor<$t>, 
+            config: &Self::CPOOL
+        ) -> Result<(), ::co::error::Error> {
+            unimplemented!();
+            Ok(())
+        }
+    );
+}
+
+impl_oconf_for_cc!(f32, f64);
+impl_oconf_for_clrn!(f32, f64);
+impl_oconf_for_pooling!(f32, f64);
+
+impl NN<f32> for Backend<Native> {
+    type CC = ConvolutionConfig;
+    type CLRN = NormalizationConfig;
+    type CPOOL = PoolingConfig;
+
+    fn init_nn() { }
+    fn device(&self) -> &DeviceType { self.device() }
 
     impl_ops_sigmoid_for!(f32, Backend<Native>);
+    impl_ops_relu_for!(f32, Backend<Native>);
+    impl_ops_tanh_for!(f32, Backend<Native>);
+    impl_ops_convolution_for!(f32, Backend<Native>);
+    impl_ops_softmax_for!(f32, Backend<Native>);
+    impl_ops_lrn_for!(f32, Backend<Native>);
+    impl_ops_pooling_for!(f32, Backend<Native>);
 
-    fn binary(&self) -> &Self::B {
-        self.binary()
+    fn new_convolution_config(
+        &self, 
+        src: &::co::tensor::SharedTensor<f32>, 
+        dest: &::co::tensor::SharedTensor<f32>, 
+        filter: &mut ::co::tensor::SharedTensor<f32>, 
+        stride: &[i32], 
+        zero_padding: &[i32]
+    ) -> Result<Self::CC, ::co::error::Error> {
+        unimplemented!();
+        Ok(ConvolutionConfig{dummy: 5})
     }
 
-    fn device(&self) -> &DeviceType {
-        self.device()
-    }
 }
 
-impl INn<f64> for Backend<Native> {
-    type B = Binary;
+impl NN<f64> for Backend<Native> {
+    type CC = ConvolutionConfig;
+    type CLRN = NormalizationConfig;
+    type CPOOL = PoolingConfig;
+
+    fn init_nn() { }
+    fn device(&self) -> &DeviceType { self.device() }
 
     impl_ops_sigmoid_for!(f64, Backend<Native>);
+    impl_ops_relu_for!(f64, Backend<Native>);
+    impl_ops_tanh_for!(f64, Backend<Native>);
+    impl_ops_convolution_for!(f64, Backend<Native>);
+    impl_ops_softmax_for!(f64, Backend<Native>);
+    impl_ops_lrn_for!(f64, Backend<Native>);
+    impl_ops_pooling_for!(f64, Backend<Native>);
 
-    fn binary(&self) -> &Self::B {
-        self.binary()
-    }
-
-    fn device(&self) -> &DeviceType {
-        self.device()
+    fn new_convolution_config(
+        &self, 
+        src: &::co::tensor::SharedTensor<f64>, 
+        dest: &::co::tensor::SharedTensor<f64>, 
+        filter: &mut ::co::tensor::SharedTensor<f64>, 
+        stride: &[i32], 
+        zero_padding: &[i32]
+    ) -> Result<Self::CC, ::co::error::Error> {
+        unimplemented!();
+        Ok(ConvolutionConfig{dummy: 5})
     }
 }
+
+

--- a/tests/convolution_specs.rs
+++ b/tests/convolution_specs.rs
@@ -2,7 +2,8 @@ extern crate collenchyma_nn as co_nn;
 extern crate collenchyma as co;
 
 #[cfg(test)]
-mod convolution_spec {
+#[cfg(feature = "cuda")]
+mod convolution_spec_cuda {
 
     use co::backend::{Backend, BackendConfig};
     use co::framework::IFramework;
@@ -273,4 +274,171 @@ mod convolution_spec {
         }
     }
     */
+}
+
+#[cfg(test)]
+#[cfg(feature = "native")]
+mod convolution_spec_native{
+
+    use co::backend::{Backend, BackendConfig};
+    use co::framework::IFramework;
+    use co::frameworks::Native;
+    use co_nn::*;
+    use co::memory::MemoryType;
+    use co::tensor::SharedTensor;
+    use co::plugin::numeric_helpers::{cast, Float};
+
+    fn get_native_backend() -> Backend<Native> {
+        let framework = Native::new();
+        let hardwares = framework.hardwares();
+        let backend_config = BackendConfig::new(framework, hardwares);
+        Backend::new(backend_config).unwrap()
+    }
+
+    fn write_to_memory<T: Copy>(mem: &mut MemoryType, data: &[T]) {
+        let &mut MemoryType::Native(ref mut mem) = mem;
+        let mut mem_buffer = mem.as_mut_slice::<T>();
+        for (index, datum) in data.iter().enumerate() {
+            mem_buffer[index] = *datum;
+        }
+    }
+
+    fn get_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let batch = 4;
+        let w1 = 9;
+        let h1 = 9;
+        let d1 = 3;
+        let k = 6;
+        let f = 3;
+        let w2 = (w1 - f + 0) / 1;
+        let h2 = (h1 - f + 0) / 1;
+        let mut x = SharedTensor::<T>::new(backend.device(), &(batch, d1, h1, w1)).unwrap();
+        let mut payload: &mut [T] = &mut ::std::iter::repeat(val).take(x.capacity()).collect::<Vec<T>>();
+        payload[0] = val2;
+        write_to_memory(x.get_mut(backend.device()).unwrap(), payload);
+
+        let mut filter = SharedTensor::<T>::new(backend.device(), &(k, d1, f, f)).unwrap();
+        let payload: &[T] = &::std::iter::repeat(val).take(filter.capacity()).collect::<Vec<T>>();
+        write_to_memory(filter.get_mut(backend.device()).unwrap(), payload);
+
+        let mut result = SharedTensor::<T>::new(backend.device(), &(batch, k, h2, w2)).unwrap();
+        let payload: &[T] = &::std::iter::repeat(val2).take(result.capacity()).collect::<Vec<T>>();
+        write_to_memory(result.get_mut(backend.device()).unwrap(), payload);
+
+        (x, result, filter)
+    }
+
+    #[allow(dead_code)]
+    fn get_grad_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>, SharedTensor<T>, SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let batch = 4;
+        let w1 = 9;
+        let h1 = 9;
+        let d1 = 3;
+        let k = 6;
+        let f = 3;
+        let w2 = (w1 - f + 0) / 1;
+        let h2 = (h1 - f + 0) / 1;
+
+        let mut x = SharedTensor::<T>::new(backend.device(), &(batch, d1, h1, w1)).unwrap();
+        let mut payload: &mut [T] = &mut ::std::iter::repeat(val).take(x.capacity()).collect::<Vec<T>>();
+        payload[0] = val2;
+        write_to_memory(x.get_mut(backend.device()).unwrap(), payload);
+
+        let mut x_diff = SharedTensor::<T>::new(backend.device(), &(batch, k, h2, w2)).unwrap();
+        let mut payload: &mut [T] = &mut ::std::iter::repeat(val).take(x_diff.capacity()).collect::<Vec<T>>();
+        payload[0] = val2;
+        write_to_memory(x_diff.get_mut(backend.device()).unwrap(), payload);
+
+        let mut filter = SharedTensor::<T>::new(backend.device(), &(k, d1, f, f)).unwrap();
+        let payload: &[T] = &::std::iter::repeat(val).take(filter.capacity()).collect::<Vec<T>>();
+        write_to_memory(filter.get_mut(backend.device()).unwrap(), payload);
+
+        let mut result = SharedTensor::<T>::new(backend.device(), &(batch, k, h2, w2)).unwrap();
+        let payload: &[T] = &::std::iter::repeat(val).take(result.capacity()).collect::<Vec<T>>();
+        write_to_memory(result.get_mut(backend.device()).unwrap(), payload);
+
+        let result_diff = SharedTensor::<T>::new(backend.device(), &(batch, k, h2, w2)).unwrap();
+
+        (x, x_diff, result, result_diff, filter)
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_convolution_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut result, mut filter) = get_memory::<f32, Native>(&backend);
+
+        let conf = backend.new_convolution_config(&x, &result, &mut filter, &vec!(1,1), &vec!(0,0)).unwrap();
+        match backend.convolution(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    let mut payload: &mut [f32] = &mut ::std::iter::repeat(27f32).take(result.capacity()).collect::<Vec<f32>>();
+                    payload[0] = 28f32;
+                    assert_eq!(payload, mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_convolution_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut result, mut filter) = get_memory::<f64, Native>(&backend);
+
+        let conf = backend.new_convolution_config(&x, &result, &mut filter, &vec!(1,1), &vec!(0,0)).unwrap();
+        match backend.convolution(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    let mut payload: &mut [f64] = &mut ::std::iter::repeat(27f64).take(result.capacity()).collect::<Vec<f64>>();
+                    payload[0] = 28f64;
+                    assert_eq!(payload, mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_convolution_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result, mut filter) = get_memory::<f32, Native>(&backend);
+
+        let conf = backend.new_convolution_config(&x, &result, &mut filter, &vec!(1,1), &vec!(0,0)).unwrap();
+        match backend.convolution_plain(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    let mut payload: &mut [f32] = &mut ::std::iter::repeat(27f32).take(result.capacity()).collect::<Vec<f32>>();
+                    payload[0] = 28f32;
+                    assert_eq!(payload, mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_convolution_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result, mut filter) = get_memory::<f64, Native>(&backend);
+
+        let conf = backend.new_convolution_config(&x, &result, &mut filter, &vec!(1,1), &vec!(0,0)).unwrap();
+        match backend.convolution_plain(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    let mut payload: &mut [f64] = &mut ::std::iter::repeat(27f64).take(result.capacity()).collect::<Vec<f64>>();
+                    payload[0] = 28f64;
+                    assert_eq!(payload, mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
 }

--- a/tests/lrn_specs.rs
+++ b/tests/lrn_specs.rs
@@ -2,7 +2,8 @@ extern crate collenchyma_nn as co_nn;
 extern crate collenchyma as co;
 
 #[cfg(test)]
-mod lrn_spec {
+#[cfg(feature = "cuda")]
+mod lrn_spec_cuda {
 
     use co::backend::{Backend, BackendConfig};
     use co::framework::IFramework;
@@ -214,6 +215,198 @@ mod lrn_spec {
             Ok(_) => {
                 result_diff.sync(native.device()).unwrap();
                 if let Some(mem) = result_diff.get(native.device()).unwrap().as_native() {
+                    assert_eq!(&[0.594536669478436f64, 0.594536669478436f64, 1.188672127844352f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "native")]
+mod lrn_spec_native {
+
+    use co::backend::{Backend, BackendConfig};
+    use co::framework::IFramework;
+    use co::frameworks::Native;
+    use co_nn::*;
+    use co::memory::MemoryType;
+    use co::tensor::SharedTensor;
+    use co::plugin::numeric_helpers::{cast, Float};
+
+    fn get_native_backend() -> Backend<Native> {
+        let framework = Native::new();
+        let hardwares = framework.hardwares();
+        let backend_config = BackendConfig::new(framework, hardwares);
+        Backend::new(backend_config).unwrap()
+    }
+
+    fn write_to_memory<T: Copy>(mem: &mut MemoryType, data: &[T]) {
+        let &mut MemoryType::Native(ref mut mem) = mem;
+        let mut mem_buffer = mem.as_mut_slice::<T>();
+        for (index, datum) in data.iter().enumerate() {
+            mem_buffer[index] = *datum;
+        }
+    }
+
+    fn get_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, result)
+    }
+
+    fn get_grad_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>, SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut x_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x_diff.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut result = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(result.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, x_diff, result, result_diff)
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_lrn_on_cuda_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        let conf = NN::<f64>::new_lrn_config(&backend, 1u32, 1e-4f64, 0.75f64, 2f64).unwrap();
+        match backend.lrn(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.59458125f32, 0.59458125f32, 1.1890286f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_lrn_on_cuda_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        let conf = NN::<f64>::new_lrn_config(&backend, 1u32, 1e-4f64, 0.75f64, 2f64).unwrap();
+        match backend.lrn(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.594581260843431f64, 0.594581260843431f64, 1.1890287651464355f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_lrn_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        let conf = NN::<f64>::new_lrn_config(&backend, 1u32, 1e-4f64, 0.75f64, 2f64).unwrap();
+        match backend.lrn_plain(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.59458125f32, 0.59458125f32, 1.1890286f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_lrn_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        let conf = NN::<f64>::new_lrn_config(&backend, 1u32, 1e-4f64, 0.75f64, 2f64).unwrap();
+        match backend.lrn_plain(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.594581260843431f64, 0.594581260843431f64, 1.1890287651464355f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_lrn_grad_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        let conf = NN::<f64>::new_lrn_config(&backend, 1u32, 1e-4f64, 0.75f64, 2f64).unwrap();
+        match backend.lrn_grad(&mut x, &mut x_diff, &mut result, &mut result_diff, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.59453666f32, 0.59453666f32, 1.188672f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_lrn_grad_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        let conf = NN::<f64>::new_lrn_config(&backend, 1u32, 1e-4f64, 0.75f64, 2f64).unwrap();
+        match backend.lrn_grad(&mut x, &mut x_diff, &mut result, &mut result_diff, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.594536669478436f64, 0.594536669478436f64, 1.188672127844352f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_lrn_grad_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        let conf = NN::<f64>::new_lrn_config(&backend, 1u32, 1e-4f64, 0.75f64, 2f64).unwrap();
+        match backend.lrn_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.59453666f32, 0.59453666f32, 1.188672f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_lrn_grad_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        let conf = NN::<f64>::new_lrn_config(&backend, 1u32, 1e-4f64, 0.75f64, 2f64).unwrap();
+        match backend.lrn_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
                     assert_eq!(&[0.594536669478436f64, 0.594536669478436f64, 1.188672127844352f64], mem.as_slice::<f64>());
                 }
             },

--- a/tests/pooling_specs.rs
+++ b/tests/pooling_specs.rs
@@ -1,10 +1,12 @@
 extern crate collenchyma_nn as co_nn;
 extern crate collenchyma as co;
+#[cfg(feature = "cuda")] 
 extern crate cudnn;
 extern crate libc;
 
 #[cfg(test)]
-mod pooling_spec {
+#[cfg(feature = "cuda")]
+mod pooling_spec_cuda {
     use co::backend::{Backend, BackendConfig};
     use co::framework::IFramework;
     use co::frameworks::{Cuda, Native};
@@ -19,7 +21,6 @@ mod pooling_spec {
         let backend_config = BackendConfig::new(framework, hardwares);
         Backend::new(backend_config).unwrap()
     }
-
     fn get_cuda_backend() -> Backend<Cuda> {
         let framework = Cuda::new();
         let hardwares = framework.hardwares();
@@ -235,6 +236,217 @@ mod pooling_spec {
             Ok(_) => {
                 result_diff.sync(native.device()).unwrap();
                 if let Some(mem) = result_diff.get(native.device()).unwrap().as_native() {
+                    let payload: &[f64] = &vec!(2f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64);
+                    assert_eq!(payload, mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "native")]
+mod pooling_spec_native {
+    use co::backend::{Backend, BackendConfig};
+    use co::framework::IFramework;
+    use co::frameworks::Native;
+    use co_nn::*;
+    use co::memory::MemoryType;
+    use co::tensor::SharedTensor;
+    use co::plugin::numeric_helpers::{cast, Float};
+
+    fn get_native_backend() -> Backend<Native> {
+        let framework = Native::new();
+        let hardwares = framework.hardwares();
+        let backend_config = BackendConfig::new(framework, hardwares);
+        Backend::new(backend_config).unwrap()
+    }
+
+    fn write_to_memory<T: Copy>(mem: &mut MemoryType, data: &[T]) {
+        let &mut MemoryType::Native(ref mut mem) = mem;
+        let mut mem_buffer = mem.as_mut_slice::<T>();
+        for (index, datum) in data.iter().enumerate() {
+            mem_buffer[index] = *datum;
+        }
+    }
+
+    fn get_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f32, T>(1f32).unwrap();
+        let val2 = cast::<f32, T>(2f32).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(4, 4, 4, 4)).unwrap();
+        let mut payload: &mut [T] = &mut ::std::iter::repeat(val).take(x.capacity()).collect::<Vec<T>>();
+        payload[0] = val2;
+        write_to_memory(x.get_mut(backend.device()).unwrap(), payload);
+
+        let result = SharedTensor::<T>::new(backend.device(), &(4, 4, 2, 2)).unwrap();
+
+        (x, result)
+    }
+
+    fn get_grad_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>, SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(4, 4, 4, 4)).unwrap();
+        let mut payload: &mut [T] = &mut ::std::iter::repeat(val).take(x.capacity()).collect::<Vec<T>>();
+        payload[0] = val2;
+        write_to_memory(x.get_mut(backend.device()).unwrap(), payload);
+
+        let mut x_diff = SharedTensor::<T>::new(backend.device(), &(4, 4, 4, 4)).unwrap();
+        let mut payload: &mut [T] = &mut ::std::iter::repeat(val).take(x_diff.capacity()).collect::<Vec<T>>();
+        payload[0] = val2;
+        write_to_memory(x_diff.get_mut(backend.device()).unwrap(), payload);
+
+        let mut result = SharedTensor::<T>::new(backend.device(), &(4, 4, 2, 2)).unwrap();
+        let mut payload: &mut [T] = &mut ::std::iter::repeat(val).take(result.capacity()).collect::<Vec<T>>();
+        payload[0] = val2;
+        write_to_memory(result.get_mut(backend.device()).unwrap(), payload);
+
+        let result_diff = SharedTensor::<T>::new(backend.device(), &(4, 4, 2, 2)).unwrap();
+
+        (x, x_diff, result, result_diff)
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_pooling_max_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        let conf = NN::<f32>::new_pooling_config(&backend, &vec!(2,2), &vec!(0,0), &vec!(2,1)).unwrap();
+        match backend.pooling_max(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    let mut payload: &mut [f32] = &mut ::std::iter::repeat(1f32).take(result.capacity()).collect::<Vec<f32>>();
+                    payload[0] = 2f32;
+                    assert_eq!(payload, mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_pooling_max_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        let conf = NN::<f64>::new_pooling_config(&backend, &vec!(2,2), &vec!(0,0), &vec!(2,1)).unwrap();
+        match backend.pooling_max(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    let mut payload: &mut [f64] = &mut ::std::iter::repeat(1f64).take(result.capacity()).collect::<Vec<f64>>();
+                    payload[0] = 2f64;
+                    assert_eq!(payload, mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_pooling_max_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        let conf = NN::<f64>::new_pooling_config(&backend, &vec!(2,2), &vec!(0,0), &vec!(2,1)).unwrap();
+        match backend.pooling_max_plain(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    let mut payload: &mut [f32] = &mut ::std::iter::repeat(1f32).take(result.capacity()).collect::<Vec<f32>>();
+                    payload[0] = 2f32;
+                    assert_eq!(payload, mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_pooling_max_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        let conf = NN::<f64>::new_pooling_config(&backend, &vec!(2,2), &vec!(0,0), &vec!(2,1)).unwrap();
+        match backend.pooling_max_plain(&mut x, &mut result, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    let mut payload: &mut [f64] = &mut ::std::iter::repeat(1f64).take(result.capacity()).collect::<Vec<f64>>();
+                    payload[0] = 2f64;
+                    assert_eq!(payload, mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_pooling_max_grad_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        let conf = NN::<f64>::new_pooling_config(&backend, &vec!(2,2), &vec!(0,0), &vec!(2,1)).unwrap();
+        match backend.pooling_max_grad(&mut x, &mut x_diff, &mut result, &mut result_diff, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    let payload: &[f32] = &vec!(2f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32);
+                    assert_eq!(payload, mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_pooling_max_grad_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        let conf = NN::<f64>::new_pooling_config(&backend, &vec!(2,2), &vec!(0,0), &vec!(2,1)).unwrap();
+        match backend.pooling_max_grad(&mut x, &mut x_diff, &mut result, &mut result_diff, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    let payload: &[f64] = &vec!(2f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64);
+                    assert_eq!(payload, mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_pooling_max_grad_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        let conf = NN::<f64>::new_pooling_config(&backend, &vec!(2,2), &vec!(0,0), &vec!(2,1)).unwrap();
+        match backend.pooling_max_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    let payload: &[f32] = &vec!(2f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32, 1f32, 1f32, 0f32, 0f32);
+                    assert_eq!(payload, mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_pooling_max_grad_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        let conf = NN::<f64>::new_pooling_config(&backend, &vec!(2,2), &vec!(0,0), &vec!(2,1)).unwrap();
+        match backend.pooling_max_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff, &conf) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
                     let payload: &[f64] = &vec!(2f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64, 1f64, 1f64, 0f64, 0f64);
                     assert_eq!(payload, mem.as_slice::<f64>());
                 }

--- a/tests/relu_specs.rs
+++ b/tests/relu_specs.rs
@@ -2,7 +2,8 @@ extern crate collenchyma_nn as co_nn;
 extern crate collenchyma as co;
 
 #[cfg(test)]
-mod relu_spec {
+#[cfg(feature = "cuda")]
+mod relu_spec_cuda {
 
     use co::backend::{Backend, BackendConfig};
     use co::framework::IFramework;
@@ -206,6 +207,190 @@ mod relu_spec {
             Ok(_) => {
                 result_diff.sync(native.device()).unwrap();
                 if let Some(mem) = result_diff.get(native.device()).unwrap().as_native() {
+                    assert_eq!(&[1f64, 1f64, 2f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "native")]
+mod relu_spec_native {
+
+    use co::backend::{Backend, BackendConfig};
+    use co::framework::IFramework;
+    use co::frameworks::Native;
+    use co_nn::*;
+    use co::memory::MemoryType;
+    use co::tensor::SharedTensor;
+    use co::plugin::numeric_helpers::{cast, Float};
+
+    fn get_native_backend() -> Backend<Native> {
+        let framework = Native::new();
+        let hardwares = framework.hardwares();
+        let backend_config = BackendConfig::new(framework, hardwares);
+        Backend::new(backend_config).unwrap()
+    }
+
+    fn write_to_memory<T: Copy>(mem: &mut MemoryType, data: &[T]) {
+    let &mut MemoryType::Native(ref mut mem) = mem;
+        let mut mem_buffer = mem.as_mut_slice::<T>();
+        for (index, datum) in data.iter().enumerate() {
+            mem_buffer[index] = *datum;
+        }
+    }
+
+    fn get_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, result)
+    }
+
+    fn get_grad_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>, SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut x_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x_diff.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut result = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(result.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, x_diff, result, result_diff)
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_relu_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        match backend.relu(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[1f32, 1f32, 2f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_relu_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        match backend.relu(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[1f64, 1f64, 2f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_relu_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        match backend.relu_plain(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[1f32, 1f32, 2f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_relu_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        match backend.relu_plain(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[1f64, 1f64, 2f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_relu_grad_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        match backend.relu_grad(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[1f32, 1f32, 2f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_relu_grad_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        match backend.relu_grad(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[1f64, 1f64, 2f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_relu_grad_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        match backend.relu_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[1f32, 1f32, 2f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_relu_grad_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        match backend.relu_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
                     assert_eq!(&[1f64, 1f64, 2f64], mem.as_slice::<f64>());
                 }
             },

--- a/tests/sigmoid_specs.rs
+++ b/tests/sigmoid_specs.rs
@@ -2,7 +2,8 @@ extern crate collenchyma_nn as co_nn;
 extern crate collenchyma as co;
 
 #[cfg(test)]
-mod sigmoid_spec {
+#[cfg(feature = "cuda")]
+mod sigmoid_spec_cuda{
 
     use co::backend::{Backend, BackendConfig};
     use co::framework::IFramework;
@@ -211,6 +212,190 @@ mod sigmoid_spec {
             Ok(_) => {
                 result_diff.sync(native.device()).unwrap();
                 if let Some(mem) = result_diff.get(native.device()).unwrap().as_native() {
+                    assert_eq!(&[0f64, 0f64, -4f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "native")]
+mod sigmoid_spec_native {
+
+    use co::backend::{Backend, BackendConfig};
+    use co::framework::IFramework;
+    use co::frameworks::Native;
+    use co_nn::*;
+    use co::memory::MemoryType;
+    use co::tensor::SharedTensor;
+    use co::plugin::numeric_helpers::{cast, Float};
+
+    fn get_native_backend() -> Backend<Native> {
+        let framework = Native::new();
+        let hardwares = framework.hardwares();
+        let backend_config = BackendConfig::new(framework, hardwares);
+        Backend::new(backend_config).unwrap()
+    }
+
+    fn write_to_memory<T: Copy>(mem: &mut MemoryType, data: &[T]) {
+        let &mut MemoryType::Native(ref mut mem) = mem;
+        let mut mem_buffer = mem.as_mut_slice::<T>();
+        for (index, datum) in data.iter().enumerate() {
+            mem_buffer[index] = *datum;
+        }
+    }
+
+    fn get_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, result)
+    }
+
+    fn get_grad_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>, SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut x_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x_diff.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut result = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(result.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, x_diff, result, result_diff)
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_sigmoid_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        match backend.sigmoid(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.7310585786f32, 0.7310586f32, 0.880797f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_sigmoid_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        match backend.sigmoid(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.7310585786300049f64, 0.7310585786300049f64, 0.8807970779778823f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_sigmoid_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        match backend.sigmoid_plain(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.7310585786f32, 0.7310586f32, 0.880797f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_sigmoid_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        match backend.sigmoid_plain(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.7310585786300049f64, 0.7310585786300049f64, 0.8807970779778823f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_sigmoid_grad_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        match backend.sigmoid_grad(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0f32, 0f32, -4f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_sigmoid_grad_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        match backend.sigmoid_grad(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0f64, 0f64, -4f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_sigmoid_grad_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        match backend.sigmoid_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0f32, 0f32, -4f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_sigmoid_grad_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        match backend.sigmoid_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
                     assert_eq!(&[0f64, 0f64, -4f64], mem.as_slice::<f64>());
                 }
             },

--- a/tests/softmax_specs.rs
+++ b/tests/softmax_specs.rs
@@ -2,7 +2,8 @@ extern crate collenchyma_nn as co_nn;
 extern crate collenchyma as co;
 
 #[cfg(test)]
-mod softmax_spec {
+#[cfg(feature = "cuda")]
+mod softmax_spec_cuda {
 
     use co::backend::{Backend, BackendConfig};
     use co::framework::IFramework;
@@ -206,3 +207,186 @@ mod softmax_spec {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "native")]
+mod softmax_spec_native {
+    use co::backend::{Backend, BackendConfig};
+    use co::framework::IFramework;
+    use co::frameworks::Native;
+    use co_nn::*;
+    use co::memory::MemoryType;
+    use co::tensor::SharedTensor;
+    use co::plugin::numeric_helpers::{cast, Float};
+
+
+    fn get_native_backend() -> Backend<Native> {
+        let framework = Native::new();
+        let hardwares = framework.hardwares();
+        let backend_config = BackendConfig::new(framework, hardwares);
+        Backend::new(backend_config).unwrap()
+    }
+
+    fn write_to_memory<T: Copy>(mem: &mut MemoryType, data: &[T]) {
+        let &mut MemoryType::Native(ref mut mem) = mem;
+        let mut mem_buffer = mem.as_mut_slice::<T>();
+        for (index, datum) in data.iter().enumerate() {
+            mem_buffer[index] = *datum;
+        }
+    }
+
+
+    fn get_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 4)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val, val]);
+
+        let result = SharedTensor::<T>::new(backend.device(), &(1, 1, 4)).unwrap();
+
+        (x, result)
+    }
+
+    fn get_grad_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut x_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x_diff.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, x_diff, result_diff)
+    }
+
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_softmax_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        match backend.softmax(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.25f32, 0.25f32, 0.25f32, 0.25f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_softmax_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        match backend.softmax(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.25f64, 0.25f64, 0.25f64, 0.25f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_softmax_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        match backend.softmax_plain(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.25f32, 0.25f32, 0.25f32, 0.25f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_softmax_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        match backend.softmax_plain(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.25f64, 0.25f64, 0.25f64, 0.25f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_softmax_grad_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        match backend.softmax_grad(&mut x, &mut x_diff, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[-5f32, -5f32, -8f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_softmax_grad_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        match backend.softmax_grad(&mut x, &mut x_diff, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[-5f64, -5f64, -8f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_softmax_grad_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        match backend.softmax_grad_plain(&mut x, &mut x_diff, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[-5f32, -5f32, -8f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_softmax_grad_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        match backend.softmax_grad_plain(&mut x, &mut x_diff, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[-5f64, -5f64, -8f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+}
+

--- a/tests/tanh_specs.rs
+++ b/tests/tanh_specs.rs
@@ -2,7 +2,8 @@ extern crate collenchyma_nn as co_nn;
 extern crate collenchyma as co;
 
 #[cfg(test)]
-mod tanh_spec {
+#[cfg(feature = "cuda")]
+mod tanh_spec_cuda {
 
     use co::backend::{Backend, BackendConfig};
     use co::framework::IFramework;
@@ -206,6 +207,190 @@ mod tanh_spec {
             Ok(_) => {
                 result_diff.sync(native.device()).unwrap();
                 if let Some(mem) = result_diff.get(native.device()).unwrap().as_native() {
+                    assert_eq!(&[0f64, 0f64, -6f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "native")]
+mod tanh_spec_native {
+
+    use co::backend::{Backend, BackendConfig};
+    use co::framework::IFramework;
+    use co::frameworks::Native;
+    use co_nn::*;
+    use co::memory::MemoryType;
+    use co::tensor::SharedTensor;
+    use co::plugin::numeric_helpers::{cast, Float};
+
+    fn get_native_backend() -> Backend<Native> {
+        let framework = Native::new();
+        let hardwares = framework.hardwares();
+        let backend_config = BackendConfig::new(framework, hardwares);
+        Backend::new(backend_config).unwrap()
+    }
+
+    fn write_to_memory<T: Copy>(mem: &mut MemoryType, data: &[T]) {
+        let &mut MemoryType::Native(ref mut mem) = mem;
+        let mut mem_buffer = mem.as_mut_slice::<T>();
+        for (index, datum) in data.iter().enumerate() {
+            mem_buffer[index] = *datum;
+        }
+    }
+
+    fn get_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, result)
+    }
+
+    fn get_grad_memory<T: Float, B: IFramework + Clone>(backend: &Backend<B>) -> (SharedTensor<T>, SharedTensor<T>, SharedTensor<T>, SharedTensor<T>){
+        let val = cast::<f64, T>(1f64).unwrap();
+        let val2 = cast::<f64, T>(2f64).unwrap();
+        let mut x = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut x_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(x_diff.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let mut result = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+        write_to_memory(result.get_mut(backend.device()).unwrap(), &[val, val, val2]);
+
+        let result_diff = SharedTensor::<T>::new(backend.device(), &(1, 1, 3)).unwrap();
+
+        (x, x_diff, result, result_diff)
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_tanh_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        match backend.tanh(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.7615942f32, 0.7615942f32, 0.9640276f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_tanh_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        match backend.tanh(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.7615941559557649f64, 0.7615941559557649f64, 0.9640275800758169f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_tanh_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f32, Native>(&backend);
+
+        match backend.tanh_plain(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.7615942f32, 0.7615942f32, 0.9640276f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_tanh_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut result) = get_memory::<f64, Native>(&backend);
+
+        match backend.tanh_plain(&mut x, &mut result) {
+            Ok(_) => {
+                if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0.7615941559557649f64, 0.7615941559557649f64, 0.9640275800758169f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_tanh_grad_on_native_for_f32() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        match backend.tanh_grad(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0f32, 0f32, -6f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_tanh_grad_on_native_for_f64() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        match backend.tanh_grad(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0f64, 0f64, -6f64], mem.as_slice::<f64>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_tanh_grad_on_native_for_f32_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
+
+        match backend.tanh_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
+                    assert_eq!(&[0f32, 0f32, -6f32], mem.as_slice::<f32>());
+                }
+            },
+            Err(err) => { println!("{:?}", err); assert!(false) }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn it_computes_correct_tanh_grad_on_native_for_f64_plain() {
+        let backend = get_native_backend();
+        let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
+
+        match backend.tanh_grad_plain(&mut x, &mut x_diff, &mut result, &mut result_diff) {
+            Ok(_) => {
+                if let Some(mem) = result_diff.get(backend.device()).unwrap().as_native() {
                     assert_eq!(&[0f64, 0f64, -6f64], mem.as_slice::<f64>());
                 }
             },


### PR DESCRIPTION
A significant refactor of the code was merged recently that implemented the cuda
back end. Native and OpenCL were left behind and commented out. Further,
building with `cargo test --no-default-features --feature native` failed because
cudann was still being pulled in by the tests. This commit:
1. fixes the cfg guards so dropping cuda support is possible for some people.
2. Adds the function stubs for the Native backend. These are left w/
   notimplemented!();
3. The same tests for the cuda backend are copy/pasted and refactored to apply
   to the Native backend.

This puts us in a good position for someone to just implement the Native backend
functions now.

NB: There is still a failing test for people building without Cuda: the lib.rs doc test. However, adding a
cfg guard to it uglifies it too much for it to remain a useful example, so I left it alone.

r? @MichaelHirn 
