### PR TITLE
feat/native Implemnt Sigmoid, ReLU, and tanh for Native back ends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ lazy_static = "0.1"
 
 clippy = { version = "0.0.27", optional = true }
 
+[dev-dependencies]
+
+rand = "0.3"
+
 [features]
 default = ["native", "cuda", "opencl"]
 native = ["collenchyma/native"]

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -1,0 +1,88 @@
+#![feature(test)]
+#![feature(clone_from_slice)]
+
+extern crate test;
+extern crate collenchyma as co;
+extern crate collenchyma_nn as co_nn;
+extern crate rand;
+
+use test::Bencher;
+use co::backend::{Backend, BackendConfig};
+use co::frameworks::Native;
+use co::framework::IFramework;
+use co::tensor::SharedTensor;
+use co_nn::*;
+
+use rand::{thread_rng, Rng};
+
+fn backend() -> Backend<Native> {
+    let framework = Native::new();
+    let hardwares = framework.hardwares();
+    let backend_config = BackendConfig::new(framework, hardwares);
+    Backend::new(backend_config).unwrap()
+}
+
+fn arguments<T: IFramework + Clone>(backend: &Backend<T>, size: usize) -> (SharedTensor<f32>, SharedTensor<f32>) {
+    let mut rng = thread_rng();
+    let slice_x = rng.gen_iter::<f32>().take(size).collect::<Vec<f32>>();
+
+    let mut x = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let out = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    x.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    (x, out)
+}
+
+fn arguments_grad<T: IFramework + Clone>(backend: &Backend<T>, size: usize) -> (SharedTensor<f32>, SharedTensor<f32>, SharedTensor<f32>, SharedTensor<f32>) {
+    let mut rng = thread_rng();
+    let slice_x = rng.gen_iter::<f32>().take(size).collect::<Vec<f32>>();
+
+    let mut x = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let mut dx = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let mut out = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let dout = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    x.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    dx.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    out.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    (x, dx, out, dout)
+}
+
+#[inline(never)]
+fn bench_profile<F: FnMut() -> ()>(
+    b: &mut Bencher,
+    mut bench_func: F,
+    times: usize
+) {
+    b.iter(|| { for _ in 0..times { bench_func(); } });
+}
+
+#[bench]
+fn bench_1000_relu_100_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut out) = arguments(&backend, 100);
+    let mut func = || { let _ = backend.relu_plain(&mut x, &mut out); };
+    { func(); bench_profile(b, func, 1000); }
+}
+
+#[bench]
+fn bench_10_relu_10000_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut out) = arguments(&backend, 10000);
+    let mut func = || { let _ = backend.relu_plain(&mut x, &mut out); };
+    { func(); bench_profile(b, func, 10); }
+}
+
+#[bench]
+fn bench_1000_relu_grad_100_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut dx, mut out, mut dout) = arguments_grad(&backend, 100);
+    let mut func = || { let _ = backend.relu_grad_plain(&mut x, &mut dx, &mut out, &mut dout); };
+    { func(); bench_profile(b, func, 1000); }
+}
+
+#[bench]
+fn bench_10_relu_grad_10000_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut dx, mut out, mut dout) = arguments_grad(&backend, 10000);
+    let mut func = || { let _ = backend.relu_grad_plain(&mut x, &mut dx, &mut out, &mut dout); };
+    { func(); bench_profile(b, func, 10); }
+}

--- a/benches/sigmoid.rs
+++ b/benches/sigmoid.rs
@@ -1,0 +1,88 @@
+#![feature(test)]
+#![feature(clone_from_slice)]
+
+extern crate test;
+extern crate collenchyma as co;
+extern crate collenchyma_nn as co_nn;
+extern crate rand;
+
+use test::Bencher;
+use co::backend::{Backend, BackendConfig};
+use co::frameworks::Native;
+use co::framework::IFramework;
+use co::tensor::SharedTensor;
+use co_nn::*;
+
+use rand::{thread_rng, Rng};
+
+fn backend() -> Backend<Native> {
+    let framework = Native::new();
+    let hardwares = framework.hardwares();
+    let backend_config = BackendConfig::new(framework, hardwares);
+    Backend::new(backend_config).unwrap()
+}
+
+fn arguments<T: IFramework + Clone>(backend: &Backend<T>, size: usize) -> (SharedTensor<f32>, SharedTensor<f32>) {
+    let mut rng = thread_rng();
+    let slice_x = rng.gen_iter::<f32>().take(size).collect::<Vec<f32>>();
+
+    let mut x = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let out = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    x.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    (x, out)
+}
+
+fn arguments_grad<T: IFramework + Clone>(backend: &Backend<T>, size: usize) -> (SharedTensor<f32>, SharedTensor<f32>, SharedTensor<f32>, SharedTensor<f32>) {
+    let mut rng = thread_rng();
+    let slice_x = rng.gen_iter::<f32>().take(size).collect::<Vec<f32>>();
+
+    let mut x = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let mut dx = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let mut out = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let dout = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    x.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    dx.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    out.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    (x, dx, out, dout)
+}
+
+#[inline(never)]
+fn bench_profile<F: FnMut() -> ()>(
+    b: &mut Bencher,
+    mut bench_func: F,
+    times: usize
+) {
+    b.iter(|| { for _ in 0..times { bench_func(); } });
+}
+
+#[bench]
+fn bench_1000_sigmoid_100_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut out) = arguments(&backend, 100);
+    let mut func = || { let _ = backend.sigmoid_plain(&mut x, &mut out); };
+    { func(); bench_profile(b, func, 1000); }
+}
+
+#[bench]
+fn bench_10_sigmoid_10000_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut out) = arguments(&backend, 10000);
+    let mut func = || { let _ = backend.sigmoid_plain(&mut x, &mut out); };
+    { func(); bench_profile(b, func, 10); }
+}
+
+#[bench]
+fn bench_1000_sigmoid_grad_100_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut dx, mut out, mut dout) = arguments_grad(&backend, 100);
+    let mut func = || { let _ = backend.sigmoid_grad_plain(&mut x, &mut dx, &mut out, &mut dout); };
+    { func(); bench_profile(b, func, 1000); }
+}
+
+#[bench]
+fn bench_10_sigmoid_grad_10000_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut dx, mut out, mut dout) = arguments_grad(&backend, 10000);
+    let mut func = || { let _ = backend.sigmoid_grad_plain(&mut x, &mut dx, &mut out, &mut dout); };
+    { func(); bench_profile(b, func, 10); }
+}

--- a/benches/tanh.rs
+++ b/benches/tanh.rs
@@ -1,0 +1,88 @@
+#![feature(test)]
+#![feature(clone_from_slice)]
+
+extern crate test;
+extern crate collenchyma as co;
+extern crate collenchyma_nn as co_nn;
+extern crate rand;
+
+use test::Bencher;
+use co::backend::{Backend, BackendConfig};
+use co::frameworks::Native;
+use co::framework::IFramework;
+use co::tensor::SharedTensor;
+use co_nn::*;
+
+use rand::{thread_rng, Rng};
+
+fn backend() -> Backend<Native> {
+    let framework = Native::new();
+    let hardwares = framework.hardwares();
+    let backend_config = BackendConfig::new(framework, hardwares);
+    Backend::new(backend_config).unwrap()
+}
+
+fn arguments<T: IFramework + Clone>(backend: &Backend<T>, size: usize) -> (SharedTensor<f32>, SharedTensor<f32>) {
+    let mut rng = thread_rng();
+    let slice_x = rng.gen_iter::<f32>().take(size).collect::<Vec<f32>>();
+
+    let mut x = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let out = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    x.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    (x, out)
+}
+
+fn arguments_grad<T: IFramework + Clone>(backend: &Backend<T>, size: usize) -> (SharedTensor<f32>, SharedTensor<f32>, SharedTensor<f32>, SharedTensor<f32>) {
+    let mut rng = thread_rng();
+    let slice_x = rng.gen_iter::<f32>().take(size).collect::<Vec<f32>>();
+
+    let mut x = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let mut dx = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let mut out = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    let dout = SharedTensor::<f32>::new(backend.device(), &size).unwrap();
+    x.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    dx.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    out.get_mut(backend.device()).unwrap().as_mut_native().unwrap().as_mut_slice().clone_from_slice(&slice_x);
+    (x, dx, out, dout)
+}
+
+#[inline(never)]
+fn bench_profile<F: FnMut() -> ()>(
+    b: &mut Bencher,
+    mut bench_func: F,
+    times: usize
+) {
+    b.iter(|| { for _ in 0..times { bench_func(); } });
+}
+
+#[bench]
+fn bench_1000_tanh_100_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut out) = arguments(&backend, 100);
+    let mut func = || { let _ = backend.tanh_plain(&mut x, &mut out); };
+    { func(); bench_profile(b, func, 1000); }
+}
+
+#[bench]
+fn bench_10_tanh_10000_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut out) = arguments(&backend, 10000);
+    let mut func = || { let _ = backend.tanh_plain(&mut x, &mut out); };
+    { func(); bench_profile(b, func, 10); }
+}
+
+#[bench]
+fn bench_1000_tanh_grad_100_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut dx, mut out, mut dout) = arguments_grad(&backend, 100);
+    let mut func = || { let _ = backend.tanh_grad_plain(&mut x, &mut dx, &mut out, &mut dout); };
+    { func(); bench_profile(b, func, 1000); }
+}
+
+#[bench]
+fn bench_10_tanh_grad_10000_native(b: &mut Bencher) {
+    let backend = backend();
+    let (mut x, mut dx, mut out, mut dout) = arguments_grad(&backend, 10000);
+    let mut func = || { let _ = backend.tanh_grad_plain(&mut x, &mut dx, &mut out, &mut dout); };
+    { func(); bench_profile(b, func, 10); }
+}

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,11 @@
+# Profiling
+
+Collenchyma comes with scripts to help with profiling performance problems.
+
+Run [perf](http://www.brendangregg.com/perf.html) on one of the benchmark test:
+
+```sh
+# compile latest version of benchmarks with DWARF information
+cargo rustc --bench [bench_file_name] -- -g
+sudo ./perf/run_perf.sh [bench_fn_name] # perf needs sudo
+```

--- a/perf/perf_rblas.sh
+++ b/perf/perf_rblas.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+perf record -a -g --output perf_rblas_data.perf target/debug/rblas_overhead-cf1a2670c118749d --bench bench_1000_dot_100_rblas
+perf script -f -i perf_rblas_data.perf > perf_rblas_script.perf
+/home/hobofan/stuff/FlameGraph/stackcollapse-perf.pl perf_rblas_script.perf > perf_rblas_folded.perf
+/home/hobofan/stuff/FlameGraph/flamegraph.pl perf_rblas_folded.perf > perf_rblas_graph.svg

--- a/perf/run_perf.sh
+++ b/perf/run_perf.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+if [ $# -eq 0 ]
+  then
+    echo "No benchmark name supplied"
+    exit 1
+fi
+benchname=$1
+mkdir -p target/perf
+perf record -a -g --output target/perf/${benchname}.data target/debug/rblas_overhead-c02a41a1401d43da --bench ${benchname}
+perf script -f -i target/perf/${benchname}.data > target/perf/${benchname}.scripted
+stackcollapse-perf target/perf/${benchname}.scripted | grep ${benchname} > target/perf/${benchname}.folded
+flamegraph target/perf/${benchname}.folded > target/perf/${benchname}.svg

--- a/tests/relu_specs.rs
+++ b/tests/relu_specs.rs
@@ -271,7 +271,6 @@ mod relu_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_relu_on_native_for_f32() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f32, Native>(&backend);
@@ -287,7 +286,6 @@ mod relu_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_relu_on_native_for_f64() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f64, Native>(&backend);
@@ -303,7 +301,6 @@ mod relu_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_relu_on_native_for_f32_plain() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f32, Native>(&backend);
@@ -319,7 +316,6 @@ mod relu_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_relu_on_native_for_f64_plain() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f64, Native>(&backend);
@@ -335,7 +331,6 @@ mod relu_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_relu_grad_on_native_for_f32() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
@@ -351,7 +346,6 @@ mod relu_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_relu_grad_on_native_for_f64() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
@@ -367,7 +361,6 @@ mod relu_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_relu_grad_on_native_for_f32_plain() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
@@ -383,7 +376,6 @@ mod relu_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_relu_grad_on_native_for_f64_plain() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);

--- a/tests/sigmoid_specs.rs
+++ b/tests/sigmoid_specs.rs
@@ -276,7 +276,6 @@ mod sigmoid_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_sigmoid_on_native_for_f32() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f32, Native>(&backend);
@@ -285,6 +284,8 @@ mod sigmoid_spec_native {
             Ok(_) => {
                 if let Some(mem) = result.get(backend.device()).unwrap().as_native() {
                     assert_eq!(&[0.7310585786f32, 0.7310586f32, 0.880797f32], mem.as_slice::<f32>());
+                } else {
+                    println!("No result: {:?}", result); assert!(false);
                 }
             },
             Err(err) => { println!("{:?}", err); assert!(false) }
@@ -292,7 +293,6 @@ mod sigmoid_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_sigmoid_on_native_for_f64() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f64, Native>(&backend);
@@ -308,7 +308,6 @@ mod sigmoid_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_sigmoid_on_native_for_f32_plain() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f32, Native>(&backend);
@@ -324,7 +323,6 @@ mod sigmoid_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_sigmoid_on_native_for_f64_plain() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f64, Native>(&backend);
@@ -340,7 +338,6 @@ mod sigmoid_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_sigmoid_grad_on_native_for_f32() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
@@ -356,7 +353,6 @@ mod sigmoid_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_sigmoid_grad_on_native_for_f64() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
@@ -372,7 +368,6 @@ mod sigmoid_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_sigmoid_grad_on_native_for_f32_plain() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
@@ -388,7 +383,6 @@ mod sigmoid_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_sigmoid_grad_on_native_for_f64_plain() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);

--- a/tests/tanh_specs.rs
+++ b/tests/tanh_specs.rs
@@ -271,7 +271,6 @@ mod tanh_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_tanh_on_native_for_f32() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f32, Native>(&backend);
@@ -287,7 +286,6 @@ mod tanh_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_tanh_on_native_for_f64() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f64, Native>(&backend);
@@ -303,7 +301,6 @@ mod tanh_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_tanh_on_native_for_f32_plain() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f32, Native>(&backend);
@@ -319,7 +316,6 @@ mod tanh_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_tanh_on_native_for_f64_plain() {
         let backend = get_native_backend();
         let (mut x, mut result) = get_memory::<f64, Native>(&backend);
@@ -335,7 +331,6 @@ mod tanh_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_tanh_grad_on_native_for_f32() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
@@ -351,7 +346,6 @@ mod tanh_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_tanh_grad_on_native_for_f64() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);
@@ -367,7 +361,6 @@ mod tanh_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_tanh_grad_on_native_for_f32_plain() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f32, Native>(&backend);
@@ -383,7 +376,6 @@ mod tanh_spec_native {
     }
 
     #[test]
-    #[ignore]
     fn it_computes_correct_tanh_grad_on_native_for_f64_plain() {
         let backend = get_native_backend();
         let (mut x, mut x_diff, mut result, mut result_diff) = get_grad_memory::<f64, Native>(&backend);


### PR DESCRIPTION
This implements Sigmoid, ReLU, and tanh activation functions for the native backend. This includes the grad functions too.

Notes:
- The tests only use the same numbers as the cudaback end tests. They are only the first level of testing (does it ever work?) and don't cover (does it behave nicely in the face of failure?)
- `write_to_memory` should be moved to a single common function somewhere (`co`?). Currently it is copy pasted in the tests (twice in each) and in the native back ends.
- The unwrapping of SharedTensors is pretty nasty (nested `if let`s). Perhaps this could be abstracted into an iterator or a deeper function that does all the unwrapping we want. I think this is a side issue from the implementations as they stand now. A side effect of the nested if lets is that I had to make up stupid variable names which don't add anything to the readability.
- I noticed that `write_to_memory` doesn't work nicely in the face of different features being enabled. If only one feature is enabled, Rust doesn't like that we use an if let because there's only one possible backend. If we use multiple backends then it doesn't like it when we /dont/ use an if let since we aren't sure about the results of the backend resolution.

I don't know if you want to merge this and pull the issues into issues; or if you want these to be fixed in the PR, so I'll leave it up to you.

If you want to make some changes, please fork my branch and pass a PR back to me. 

Thanks!

r? @MichaelHirn
